### PR TITLE
Fix a bug preventing window::raw::{enum_by/enum_by_until} from working after an OS-error is set

### DIFF
--- a/src/raw/window.rs
+++ b/src/raw/window.rs
@@ -110,7 +110,6 @@ pub fn enum_by<T: FnMut(HWND)>(parent: Option<HWND>, mut cmp_func: T) -> io::Res
 
     let result: i32;
 
-    unsafe { SetLastErrorEx(0, 0) };
     if let Some(parent_window) = parent {
         result = unsafe { EnumChildWindows(parent_window, Some(callback_enum_windows::<T>), lparam) };
     }

--- a/src/raw/window.rs
+++ b/src/raw/window.rs
@@ -5,6 +5,8 @@ use std::os::windows::ffi::OsStrExt;
 use std::ptr;
 use std::ffi;
 
+use winapi::um::winuser::SetLastErrorEx;
+
 use crate::inner_raw as raw;
 use self::raw::winapi::*;
 use crate::utils;
@@ -108,6 +110,7 @@ pub fn enum_by<T: FnMut(HWND)>(parent: Option<HWND>, mut cmp_func: T) -> io::Res
 
     let result: i32;
 
+    unsafe { SetLastErrorEx(0, 0) };
     if let Some(parent_window) = parent {
         result = unsafe { EnumChildWindows(parent_window, Some(callback_enum_windows::<T>), lparam) };
     }
@@ -140,7 +143,8 @@ pub fn enum_by_until<T: FnMut(HWND) -> i32>(parent: Option<HWND>, mut cmp_func: 
     let lparam = &mut cmp_func as *mut _ as LPARAM;
 
     let result: i32;
-
+    
+    unsafe { SetLastErrorEx(0, 0) };
     if let Some(parent_window) = parent {
         result = unsafe { EnumChildWindows(parent_window, Some(callback_enum_windows_until::<T>), lparam) };
     }

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -58,20 +58,20 @@ fn rust_callback() {
 fn test_timer_builder() {
     let timer = TimerBuilder::new().rust_callback(rust_callback).single(1).interval(900).build().expect("To build timer");
     assert_eq!(RUST_CB_COUNT.load(atomic::Ordering::Relaxed), 0);
-    sleep(10);
+    sleep(100);
     assert_eq!(RUST_CB_COUNT.load(atomic::Ordering::Relaxed), 1);
     timer.delete(timer::Wait).expect("To delete timer");
 
     let timer = TimerBuilder::new().rust_callback(rust_callback).single(900).interval(900).build().expect("To build timer");
-    sleep(10);
+    sleep(100);
     assert_eq!(RUST_CB_COUNT.load(atomic::Ordering::Relaxed), 1);
     timer.reset(5, 0).expect("To reset");
-    sleep(10);
+    sleep(100);
     assert_eq!(RUST_CB_COUNT.load(atomic::Ordering::Relaxed), 2);
     timer.delete(timer::Wait).expect("To delete timer");
 
-    let timer = TimerBuilder::new().rust_callback(rust_callback).single(0).interval(6).build().expect("To build timer");
-    sleep(10);
+    let timer = TimerBuilder::new().rust_callback(rust_callback).single(0).interval(60).build().expect("To build timer");
+    sleep(100);
     assert_eq!(RUST_CB_COUNT.load(atomic::Ordering::Relaxed), 4);
     timer.delete(timer::Wait).expect("To delete timer");
 

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -2,9 +2,7 @@ extern crate windows_win;
 extern crate clipboard_win;
 extern crate winapi;
 
-use winapi::um::winuser::{
-    AddClipboardFormatListener
-};
+use winapi::um::winuser::{AddClipboardFormatListener, SetLastErrorEx};
 
 use clipboard_win::{
     set_clipboard_string
@@ -60,6 +58,7 @@ fn test_interact_notepad() {
     test_open_close(notepad.id());
     test_query_process_exe(notepad.id());
     test_get_windows_by_title(notepad.id());
+    test_get_window_by_pid_after_error(notepad.id());
     test_window_set_text_message(notepad.id());
     //This test should be last as it closes notepad
     test_window_sys_command_close(notepad.id());
@@ -112,6 +111,12 @@ fn test_get_windows_by_title(notepad_id: u32) {
     let result = result.unwrap();
 
     assert_eq!(notepad_orig_title, result);
+}
+
+fn test_get_window_by_pid_after_error(notepad_id: u32) {
+    unsafe { SetLastErrorEx(5, 0) };
+    let notepad_window = get_by_pid(notepad_id);
+    assert!(notepad_window.is_ok());
 }
 
 fn test_window_set_text_message(notepad_id: u32) {

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -181,3 +181,16 @@ fn test_window_create_dummy() {
     let window = window.unwrap();
     assert!(destroy(window));
 }
+
+#[test]
+fn check_enum_by_with_last_error_will_not_fail() {
+    unsafe {
+        SetLastErrorEx(1, 0)
+    }
+
+    let result = windows_win::raw::window::enum_by_until(None, |_| {
+        1
+    });
+
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
In case a former call to the Windows API created an error condition (i.e., setting an error on SetErrorEx()), then enum_by and enum_by_until would incorrectly always return an error as a result due to the former error not being cleaned. .Since the contract on safe Rust functions is usually to return their own error (and not carry other former errors to the user) it makes sense that enum_by
would clean the former error with SetErrorEx(0, 0) before operating.

This commit contributes the fix and also a test proving the failure to guard against a regression.

I also change the timings on timer.rs because the test was failing on my machine due to a race condition.